### PR TITLE
Bumped bower.json jQuery version up to 2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,6 @@
     "**/*.txt"
   ],
   "dependencies": {
-    "jquery": ">=1.7 <2.0"
+    "jquery": ">1.7 ~2.1.4"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "gilbitron/carouFredSel",
-  "version": "6.2.1",
-  "main": "jquery.carouFredSel-6.2.1.js",
+  "version": "6.2.2",
+  "main": "jquery.carouFredSel-6.2.2.js",
   "description": "A circular, responsive carousel plugin built using the jQuery.",
   "license": "MIT",
   "ignore": [

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 
 		<!-- include jQuery + carouFredSel plugin -->
 		<script type="text/javascript" language="javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-		<script type="text/javascript" language="javascript" src="jquery.carouFredSel-6.2.1-packed.js"></script>
+		<script type="text/javascript" language="javascript" src="jquery.carouFredSel-6.2.2-packed.js"></script>
 
 		<!-- optionally include helper plugins -->
 		<script type="text/javascript" language="javascript" src="helper-plugins/jquery.mousewheel.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 		<title>carouFredSel: a circular, responsive jQuery carousel</title>
 
 		<!-- include jQuery + carouFredSel plugin -->
-		<script type="text/javascript" language="javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+		<script type="text/javascript" language="javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
 		<script type="text/javascript" language="javascript" src="jquery.carouFredSel-6.2.1-packed.js"></script>
 
 		<!-- optionally include helper plugins -->

--- a/jquery.carouFredSel-6.2.2-packed.js
+++ b/jquery.carouFredSel-6.2.2-packed.js
@@ -1,5 +1,5 @@
 /*
- *	jQuery carouFredSel 6.2.1
+ *	jQuery carouFredSel 6.2.2
  *	Demo's and documentation:
  *	caroufredsel.dev7studios.com
  *

--- a/jquery.carouFredSel-6.2.2.js
+++ b/jquery.carouFredSel-6.2.2.js
@@ -1,5 +1,5 @@
 /*
- *	jQuery carouFredSel 6.2.1
+ *	jQuery carouFredSel 6.2.2
  *	Demo's and documentation:
  *	caroufredsel.dev7studios.com
  *


### PR DESCRIPTION
I tested the plugin with jQuery 2.1.4, which works just great. After all, jQuery 2 is backwards compatible with jQuery 1.9 (see [this article](http://blog.jquery.com/2013/04/18/jquery-2-0-released/)).

I left in the 1.7 minimum requirement, so sites that need to support IE 6-8 can still use it.
